### PR TITLE
메인 페이지 수정 등

### DIFF
--- a/CSE_frontend/src/actions/index.js
+++ b/CSE_frontend/src/actions/index.js
@@ -3,7 +3,9 @@ import axios from 'axios';
 export const FETCH_NOTICES = 'fetch_notices';
 export const FETCH_NOTICE = 'fetch_notice';
 export const CREATE_NOTICE = 'create_notice';
-export const DELETE_NOTICE = 'delete_notice';
+export const FETCH_NEWS = 'fetch_News';
+export const FETCH_NEW = 'fetch_New';
+export const CREATE_LOGIN = 'create_login';
 const ROOT_URL = 'http://127.0.0.1:8000/api';
 const API_KEY = '?key=TEMPORARY1234';
 
@@ -25,32 +27,37 @@ export function fetchNotice(id) {
 }
 
 export function createNotice(values, callback) {
-    //파일, 이미지 여러개 처리 필요.
-    var formData = new FormData();
-    values.foreach(data=> {
-        formData.append(data.key, data);
-    })
-    const request = axios.post(`${ROOT_URL}/notice${API_KEY}`, formData,
-        {
-            headers: {
-            'Content-Type': 'multipart/form-data'
-            }
-        }
-    )
+    const request = axios.post(`${ROOT_URL}/notice${API_KEY}`, values)
         .then(() => callback());
-    console.log(values.attached)
-
+    
     return {
         type: CREATE_NOTICE,
-        payload: request
+        payload: request 
     }
 }
 
-export function deleteNotice(id) {
-    const request = axios.delete(`${ROOT_URL}/notice/${id}${API_KEY}`)
-        .then(() => callback());
-    return {
-        type: DELETE_NOTICE,
-        payload: id
-    }
+export function fetchNews() {
+  const request = axios.get(`${ROOT_URL}/News${API_KEY}`)
+  return {
+    type: FETCH_NEWS,
+    payload: request
+  };
+}
+
+export function fetchNew(id) {
+  const request = axios.get(`${ROOT_URL}/New/${id}${API_KEY}`)
+  return {
+    type: FETCH_NEW,
+    payload: request
+  };
+}
+
+export function createLogin(values, callback) {
+  const request = axios.post(`${ROOT_URL}/sign_in${API_KEY}`, values)
+    .then(() => callback());
+
+  return {
+    type: CREATE_LOGIN,
+    payload: request
+  }
 }

--- a/CSE_frontend/src/components/Login.js
+++ b/CSE_frontend/src/components/Login.js
@@ -1,0 +1,66 @@
+import React, { Component } from 'react';
+import { Field, reduxForm } from 'redux-form';
+import { Link } from 'react-router-dom';
+import { connect } from 'react-redux';
+import { createLogin } from '../actions';
+
+class Login extends Component {
+  renderField(field) {
+    const { meta: { touched, error } } = field;
+    const className=`form-group ${touched && error ?  'has-danger': ''}`;
+    return (
+        
+      <div className={className}>
+      <label>{field.label}</label>
+        <input className="form-control" type="text" {...field.input} />
+        <div className="text-help">
+          {touched? error : ""}
+        </div>
+     </div>
+   );
+  }
+
+  onSubmit(values) {
+    this.props.createLogin(values, () => {
+      this.props.history.push('/sign_in');
+    });
+  }
+  render() {
+    const { handleSubmit } = this.props;
+
+    return (
+      <form onSubmit={handleSubmit(this.onSubmit.bind(this))}>
+        <Field 
+          label="ID"
+          name="username"
+          component={this.renderField}
+        />
+        <Field 
+          label="Password"
+          name="passwd"
+          component={this.renderField}
+        />
+        <button type="submit" className="btn btn-primary">Login</button>
+        <Link to="/sign_in" className="btn btn-danger">Cancel</Link>
+       </form>
+      );
+    }
+}
+
+function validate(values) {
+    const errors = {};
+    if(!values.username) {
+        errors.username = "Enter ID";
+    }
+    if(!values.passwd) {
+        errors.passwd = "Enter password";
+    }
+    return errors;
+}
+
+export default reduxForm({
+    validate,
+    form: "LoginNewForm"
+})(
+  connect(null,{ createLogin })(Login)
+);

--- a/CSE_frontend/src/components/MainPage.js
+++ b/CSE_frontend/src/components/MainPage.js
@@ -1,9 +1,106 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { fetchNotices, fetchNews } from '../actions';
 
-export default class MainPage extends Component {
+class MainPage extends Component {
+
+  constructor() {
+    super();
+
+    this.state = {
+      ntag: 0,
+    };
+  }
+
+  componentDidMount() {
+    this.props.fetchNotices();
+  }
+
+/*
+  onTagSelect(tag) {
+    this.setState(() => ({ ntag: tag }));
+  }
+*/
+
+  renderNotice() {
+    const size = _.size(this.props.notices)
+    const rev = _.reject(this.props.notices, notice => { return notice.id <= size-5; })
+    const rrev = _.chain(rev).reverse().value()
+
+    if (size == 0) {
+      return (
+        "Loading... Maybe no Notice..."
+      );
+    }
+
+    return _.map(rrev, notice => {
+      return (
+        <div>
+          <Link to={`/notice/${notice.id}`}>
+            {notice.title}
+          </Link>
+        </div>
+      );
+    });
+  }
+
+  renderNews() {
+    const size = _.size(this.props.News)
+    const rev = _.reject(this.props.News, New => { return News.id <= size-5; })
+    const rrev = _.chain(rev).reverse().value()
+
+    if (size == 0) {
+      return (
+        "Loading... Maybe no News..."
+      );
+    }
+
+    return _.map(rrev, New => {
+      return (
+        <div>
+          <Link to={`/News/${New.id}`}>
+            {New.title}
+          </Link>
+        </div>
+      );
+    });
+  }
+
   render() {
+    const { notices } = this.props;
+    const { News } = this.props;
     return (
-      <div>메인페이지</div>
+      <div>
+        <h3>Welcome to CSE department Homepage</h3>
+        <div>
+          <img src="/Pic" />
+        </div>
+        <div className="main-notice">
+          <div onClick={() => onTagSelected(tag)} className="main-notice-tag">Tag1</div>
+          <div onClick={() => onTagSelected(tag)} className="main-notice-tag">Tag2</div>
+          <div onClick={() => onTagSelected(tag)} className="main-notice-tag">Tag3</div>
+          <div onClick={() => onTagSelected(tag)} className="main-notice-tag">NoTag</div>
+          {this.renderNotice()}
+        </div>
+        <div className="main-News">
+          <div>News</div>
+          {this.renderNews()}
+        </div>
+        <div className="main-login">
+          <button>
+            <Link to={`/sign_in`}>
+              Login
+            </Link>
+          </button>
+        </div>
+      </div>
     );
   }
 }
+
+function mapStateToProps({ notices }) {
+  return { notices }
+}
+
+export default connect(mapStateToProps, { fetchNotices })(MainPage);

--- a/CSE_frontend/src/index.js
+++ b/CSE_frontend/src/index.js
@@ -10,7 +10,8 @@ import MainPage from './components/MainPage';
 import NoticeCreate from './components/NoticeCreate';
 import NoticeDetail from './components/NoticeDetail';
 import NoticeList from './components/NoticeList';
-import NoticeUpdate from './components/NoticeUpdate';
+import Login from './components/Login';
+
 import reducers from './reducers';
 
 const createStoreWithMiddleware = applyMiddleware(promise)(createStore);
@@ -23,8 +24,8 @@ ReactDOM.render(
         <Switch> 
           <Route path="/notice/new" component={NoticeCreate} />
           <Route path="/notice/:id" component={NoticeDetail} />
-          {/* <Route path="/notice/:id/update" component={NoticeUpdate} /> */}
           <Route path="/notice" component={NoticeList} />
+          <Route path="/sign_in" component={Login} />
           <Route path="/" component={MainPage} />
         </Switch>
       </div>

--- a/CSE_frontend/src/reducers/reducer_News.js
+++ b/CSE_frontend/src/reducers/reducer_News.js
@@ -1,0 +1,13 @@
+import _ from 'lodash';
+import { FETCH_NEWS, FETCH_NEW } from '../actions';
+
+export default (state = {}, action) => {
+    switch (action.type) {
+        case FETCH_NEW:
+             return { ...state, [action.payload.data.id]: action.payload.data };
+        case FETCH_NEWS:
+            return _.mapKeys(action.payload.data, 'id');
+        default:
+            return state;
+    }
+}

--- a/CSE_frontend/style/style.css
+++ b/CSE_frontend/style/style.css
@@ -1,5 +1,3 @@
-/* @import 'antd/dist/antd.css'; */
-
 .MainCategories {
     margin-right: 20px;
 }
@@ -14,4 +12,42 @@
     right: 0;
     width: auto;
     border: 1px solid #ddd8d8;
+}
+
+.main-notice {
+  border: 1px solid #ddd;
+  width: 50%;
+  height: 150px;
+  float: left;
+}
+
+.main-News {
+  border: 1px solid #ddd;
+  width: 50%;
+  height: 150px;
+  float: right;
+}
+
+.main-notice-tag {
+  border: 1px solid #ddd;
+  width: 25%;
+  height: 30px;
+  float: left;
+}
+
+.main-notice-title {
+  border: 1px solid #ddd;
+  width: 100%;
+  height: 30px;
+  float: left;
+}
+
+.main-News-title {
+  border: 1px solid #ddd;
+  width: 25%;
+  height: 30px;
+}
+
+.main-login {
+  float: right;
 }


### PR DESCRIPTION
# 메인 페이지 수정
- 로그인 버튼 추가
- 공지사항 표시(최근 순으로 5개)
- 뉴스 표시(최근 순으로 5개)
- 사진 추가 예정

# 로그인 페이지 추가
- ID, Passwd를 받는 기능만 추가

# News를 받는 기능 추가
- 아직 News 개인당 id가 존재하지 않아서 실제로는 받아오지 못함

# 구현예정
- Tag버튼을 누를때마다 Tag에 알맞는 공지사항이 나올 예정
- Pop up 창 추가 예정
- 외부 URL 연결 예정